### PR TITLE
Integrate discover documentation into GameObjectNotes

### DIFF
--- a/Packages/com.jaimecamacho.discovernotes/Editor/DiscoverVZEditor.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Editor/DiscoverVZEditor.cs
@@ -13,7 +13,35 @@ public class DiscoverVZEditor : Editor
     {
         DiscoverVZ discover = (DiscoverVZ)target;
 
-        // Bot髇 de edici髇
+        EditorGUILayout.HelpBox(
+            "DiscoverVZ es un componente legacy. Usa GameObjectNotes para gestionar notas y documentaci贸n visual.",
+            MessageType.Warning);
+
+        using (new EditorGUILayout.HorizontalScope())
+        {
+            if (GUILayout.Button("Convertir a GameObjectNotes"))
+            {
+                discover.ConvertAndRemove();
+                return;
+            }
+
+            var notes = discover.GetComponent<GameObjectNotes>();
+            if (notes == null)
+            {
+                if (GUILayout.Button("A帽adir GameObjectNotes"))
+                {
+                    Undo.AddComponent<GameObjectNotes>(discover.gameObject);
+                }
+            }
+            else if (GUILayout.Button("Seleccionar GameObjectNotes"))
+            {
+                Selection.activeObject = notes;
+            }
+        }
+
+        EditorGUILayout.Space();
+
+        // Bot贸n de edici贸n
         EditorGUILayout.BeginHorizontal();
         EditorGUILayout.LabelField(discover.category.ToString(), EditorStyles.miniLabel);
         GUILayout.FlexibleSpace();
@@ -25,7 +53,7 @@ public class DiscoverVZEditor : Editor
 
         if (isEditing)
         {
-            // Modo Edici髇
+            // Modo Edici贸n
             discover.discoverName = EditorGUILayout.TextField("Name", discover.discoverName);
             discover.category = (DiscoverVZ.DiscoverCategory)EditorGUILayout.EnumPopup("Category", discover.category);
             discover.image = (Texture2D)EditorGUILayout.ObjectField("Image", discover.image, typeof(Texture2D), false);
@@ -40,7 +68,7 @@ public class DiscoverVZEditor : Editor
                 discover.sections[i].image = (Texture2D)EditorGUILayout.ObjectField("Image", discover.sections[i].image, typeof(Texture2D), false);
                 discover.sections[i].sectionContent = EditorGUILayout.TextArea(discover.sections[i].sectionContent, GUILayout.Height(40));
 
-                // Acciones dentro de la secci髇
+                // Acciones dentro de la secci贸n
                 EditorGUILayout.LabelField("Actions", EditorStyles.boldLabel);
                 for (int j = 0; j < discover.sections[i].actions.Count; j++)
                 {
@@ -95,7 +123,7 @@ public class DiscoverVZEditor : Editor
                 }
                 EditorGUILayout.LabelField(section.sectionContent, EditorStyles.wordWrappedLabel);
 
-                // Acciones dentro de la secci髇
+                // Acciones dentro de la secci贸n
                 if (section.actions.Count > 0)
                 {
                     EditorGUILayout.Space();

--- a/Packages/com.jaimecamacho.discovernotes/Editor/NotesTooltipWindow.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Editor/NotesTooltipWindow.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -152,7 +152,49 @@ public class NotesTooltipWindow : EditorWindow
 
     void PrepareContent_PerNote()
     {
-        string raw = (_noteData?.notes ?? string.Empty).Trim();
+        var sb = new StringBuilder();
+
+        if (!string.IsNullOrWhiteSpace(_noteData?.discoverName))
+        {
+            sb.AppendLine(_noteData.discoverName.Trim());
+        }
+
+        if (!string.IsNullOrWhiteSpace(_noteData?.discoverSummary))
+        {
+            sb.AppendLine(_noteData.discoverSummary.Trim());
+            sb.AppendLine();
+        }
+
+        if (_noteData?.discoverSections != null && _noteData.discoverSections.Count > 0)
+        {
+            int added = 0;
+            foreach (var section in _noteData.discoverSections)
+            {
+                if (section == null) continue;
+                bool hasName = !string.IsNullOrWhiteSpace(section.sectionName);
+                bool hasContent = !string.IsNullOrWhiteSpace(section.sectionContent);
+                if (!hasName && !hasContent) continue;
+
+                sb.Append("• ");
+                if (hasName) sb.Append(section.sectionName.Trim());
+                if (hasContent)
+                {
+                    if (hasName) sb.Append(": ");
+                    sb.Append(section.sectionContent.Trim());
+                }
+                sb.AppendLine();
+
+                added++;
+                if (added >= 4) break;
+            }
+            if (added > 0) sb.AppendLine();
+        }
+
+        string baseNotes = _noteData?.notes ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(baseNotes))
+            sb.Append(baseNotes.Trim());
+
+        string raw = sb.ToString().Trim();
         if (raw.Length > 2000) raw = raw.Substring(0, 2000) + "…";
 
         string author = string.IsNullOrEmpty(_noteData?.author) ? "Anónimo" : _noteData.author;

--- a/Packages/com.jaimecamacho.discovernotes/Runtime/DiscoverNoteContent.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Runtime/DiscoverNoteContent.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Categories used to classify Discover notes. Shared between the legacy DiscoverVZ
+/// component and the new multi-note workflow inside <see cref="GameObjectNotes"/>.
+/// </summary>
+public enum DiscoverCategory
+{
+    VisualEffects,
+    Audio,
+    Gameplay,
+    UI,
+    Environment,
+    Systems,
+    Workflow,
+    Other
+}
+
+/// <summary>
+/// A section of structured information inside a Discover note. Sections allow grouping
+/// rich descriptions, optional imagery and navigation actions.
+/// </summary>
+[Serializable]
+public class DiscoverSection
+{
+    [Tooltip("Title displayed for this section inside the Discover note.")]
+    public string sectionName = "Section";
+
+    [Tooltip("Optional representative image. Useful for quick visual references or diagrams.")]
+    public Texture2D image;
+
+    [TextArea]
+    [Tooltip("Long form description or Markdown-like content for the section.")]
+    public string sectionContent = "Section Content";
+
+    [Tooltip("Contextual actions such as scene jumps or asset selections associated with the section.")]
+    public List<DiscoverAction> actions = new List<DiscoverAction>();
+}
+
+/// <summary>
+/// Interactive action rendered inside a Discover section.
+/// </summary>
+[Serializable]
+public class DiscoverAction
+{
+    [Tooltip("Friendly description for the action button.")]
+    public string description = "Select Target";
+
+    [Tooltip("Target object that will be pinged and framed when the action is executed.")]
+    public GameObject target;
+
+    [Tooltip("Optional helper text to explain what to inspect once the target is selected.")]
+    public string hint = string.Empty;
+}

--- a/Packages/com.jaimecamacho.discovernotes/Runtime/DiscoverVZ.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Runtime/DiscoverVZ.cs
@@ -1,43 +1,41 @@
-using System.Collections.Generic;
 using UnityEngine;
 
 /// <summary>
-/// DiscoverVZ: Sistema de documentación visual para la escena.
+/// DiscoverVZ (legacy): mantenido para compatibilidad. Toda la funcionalidad vive ahora
+/// dentro de <see cref="GameObjectNotes"/>.
 /// </summary>
-[AddComponentMenu("VirtualZone/DiscoverVZ")]
+[AddComponentMenu("VirtualZone/DiscoverVZ (Legacy)")]
 [DisallowMultipleComponent]
+[
+    System.Obsolete(
+        "DiscoverVZ ha sido fusionado con GameObjectNotes. Usa GameObjectNotes para " +
+        "crear y mantener la documentaciÃ³n visual.")
+]
 public class DiscoverVZ : MonoBehaviour
 {
-    public enum DiscoverCategory
-    {
-        VisualEffects, Audio, Gameplay, UI, Environment, Other
-    }
-
     public string discoverName = "Discover";
     public DiscoverCategory category = DiscoverCategory.Other;
     public Texture2D image;
     [TextArea] public string description = "Description of the component.";
-    public List<DiscoverSection> sections = new List<DiscoverSection>();
-}
+    public System.Collections.Generic.List<DiscoverSection> sections = new System.Collections.Generic.List<DiscoverSection>();
 
-/// <summary>
-/// Sección dentro de DiscoverVZ, que puede contener acciones.
-/// </summary>
-[System.Serializable]
-public class DiscoverSection
-{
-    public string sectionName = "Section Name";
-    public Texture2D image;
-    [TextArea] public string sectionContent = "Section Content";
-    public List<DiscoverAction> actions = new List<DiscoverAction>();
-}
+#if UNITY_EDITOR
+    void Reset()
+    {
+        if (GetComponent<GameObjectNotes>() == null)
+        {
+            UnityEditor.Undo.AddComponent<GameObjectNotes>(gameObject);
+        }
+    }
 
-/// <summary>
-/// Acción dentro de una sección, que permite navegar a un objeto.
-/// </summary>
-[System.Serializable]
-public class DiscoverAction
-{
-    public string description = "Action Name";
-    public GameObject target;
+    [ContextMenu("Convertir a GameObjectNotes y eliminar")]
+    public void ConvertAndRemove()
+    {
+        var notes = GetComponent<GameObjectNotes>();
+        if (notes == null) notes = gameObject.AddComponent<GameObjectNotes>();
+
+        notes.ImportFromDiscoverVZ();
+        UnityEditor.Undo.DestroyObjectImmediate(this);
+    }
+#endif
 }


### PR DESCRIPTION
## Summary
- extend `GameObjectNotes` with Discover metadata, structured sections, deletion rules and a DiscoverVZ import path
- add runtime definitions for Discover categories/sections/actions and mark the legacy `DiscoverVZ` component as deprecated with a conversion helper
- update the inspectors and tooltip window to edit and render the new structured Discover content

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d11b9fc4f08326b8df70aa3a36d55b