### PR TITLE
Integrate discover metadata into GameObjectNotes

### DIFF
--- a/Packages/com.jaimecamacho.discovernotes/Editor/NotesTooltipWindow.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Editor/NotesTooltipWindow.cs
@@ -199,7 +199,12 @@ public class NotesTooltipWindow : EditorWindow
 
         string author = string.IsNullOrEmpty(_noteData?.author) ? "Anónimo" : _noteData.author;
         string date = string.IsNullOrEmpty(_noteData?.dateCreated) ? DateTime.Now.ToString("dd/MM/yyyy") : _noteData.dateCreated;
+        var discipline = _noteData != null
+            ? DiscoverCategoryUtility.GetDisplayName(_noteData.discoverCategory)
+            : DiscoverCategoryUtility.GetDisplayName(DiscoverCategory.Other);
         string catName = string.IsNullOrEmpty(_noteData?.category) ? "Nota" : _noteData.category;
+        if (!string.IsNullOrEmpty(discipline))
+            catName = $"{catName} · {discipline}";
 
         float screenW = Screen.currentResolution.width;
         float maxTitleW = Mathf.Max(50f, screenW - SCREEN_MARGIN * 2f - PADDING * 2f - (iconTex != null ? (ICON + ICON_PAD) : 0f));

--- a/Packages/com.jaimecamacho.discovernotes/Runtime/DiscoverNoteContent.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Runtime/DiscoverNoteContent.cs
@@ -8,14 +8,57 @@ using UnityEngine;
 /// </summary>
 public enum DiscoverCategory
 {
-    VisualEffects,
-    Audio,
-    Gameplay,
-    UI,
-    Environment,
-    Systems,
-    Workflow,
-    Other
+    [InspectorName("FX")] VisualEffects,
+    [InspectorName("Audio")] Audio,
+    [InspectorName("Gameplay")] Gameplay,
+    [InspectorName("UI / UX")] UI,
+    [InspectorName("Environment")] Environment,
+    [InspectorName("Systems / Code")] Systems,
+    [InspectorName("Workflow / Pipeline")] Workflow,
+    [InspectorName("Other")] Other
+}
+
+/// <summary>
+/// Helper utilities shared by runtime and editor code to present Discover categories with
+/// user-friendly labels.
+/// </summary>
+public static class DiscoverCategoryUtility
+{
+    static readonly DiscoverCategory[] s_values =
+        (DiscoverCategory[])Enum.GetValues(typeof(DiscoverCategory));
+
+    static readonly string[] s_displayNames = BuildDisplayNames();
+
+    static string[] BuildDisplayNames()
+    {
+        var names = new string[s_values.Length];
+        for (int i = 0; i < s_values.Length; i++)
+            names[i] = GetDisplayName(s_values[i]);
+        return names;
+    }
+
+    public static IReadOnlyList<DiscoverCategory> Values => s_values;
+
+    public static string[] GetDisplayNamesCopy()
+    {
+        var copy = new string[s_displayNames.Length];
+        Array.Copy(s_displayNames, copy, copy.Length);
+        return copy;
+    }
+
+    public static string GetDisplayName(DiscoverCategory category)
+    {
+        var members = typeof(DiscoverCategory).GetMember(category.ToString());
+        if (members != null && members.Length > 0)
+        {
+            var attr = Attribute.GetCustomAttribute(members[0], typeof(InspectorNameAttribute)) as InspectorNameAttribute;
+            if (attr != null && !string.IsNullOrEmpty(attr.displayName))
+                return attr.displayName;
+        }
+
+        // Fallback to enum name when no attribute is present.
+        return category.ToString();
+    }
 }
 
 /// <summary>

--- a/Packages/com.jaimecamacho.discovernotes/Runtime/GameObjectNotes.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Runtime/GameObjectNotes.cs
@@ -64,7 +64,8 @@ public class GameObjectNotes : MonoBehaviour
 
         public bool HasDiscoverContent()
         {
-            return !string.IsNullOrEmpty(discoverSummary)
+            return discoverImage != null
+                || !string.IsNullOrEmpty(discoverSummary)
                 || (discoverSections != null && discoverSections.Count > 0);
         }
     }


### PR DESCRIPTION
## Summary
- surface the note title and discipline directly in the GameObjectNotes inspector header and metadata row, reusing the information when rendering fixed-mode previews
- add display helpers for discover categories so the inspector shows friendly names for areas like FX, Gameplay or UI across dropdowns and tooltips
- consider discover images as structured content and include the selected discipline in hierarchy tooltips for clearer context

## Testing
- Not run (Unity editor tooling)


------
https://chatgpt.com/codex/tasks/task_b_68d131cffc748326bc67047ff3e2a6c6