### PR TITLE
feat: unify discover notes configuration

### DIFF
--- a/Packages/com.jaimecamacho.discovernotes/NoteStyles.asset
+++ b/Packages/com.jaimecamacho.discovernotes/NoteStyles.asset
@@ -44,3 +44,13 @@ MonoBehaviour:
     cardBackground: {r: 1, g: 1, b: 1, a: 0.3}
     tooltipAccentBar: {r: 1, g: 1, b: 1, a: 1}
     tooltipBackground: {r: 0.6, g: 0.6, b: 0.6, a: 1}
+  discoverDisciplines:
+  - FX
+  - Audio
+  - Gameplay
+  - UI / UX
+  - Environment
+  - Systems / Code
+  - Workflow / Pipeline
+  - Other
+

--- a/Packages/com.jaimecamacho.discovernotes/Runtime/GameObjectNotes.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Runtime/GameObjectNotes.cs
@@ -42,15 +42,14 @@ public class GameObjectNotes : MonoBehaviour
         public string dateCreated = "";         // dd/MM/yyyy
         public string category = "Info";
 
-        [Header("Discover – Información General")]
-        public string discoverName = "Discover";
+        public string discoverName = string.Empty;
         public DiscoverCategory discoverCategory = DiscoverCategory.Other;
         public Texture2D discoverImage;
 
         [TextArea(2, 10)]
         public string discoverSummary = "";
 
-        [Header("Discover – Contenido estructurado")]
+        [Header("Contenido estructurado")]
         public List<DiscoverSection> discoverSections = new List<DiscoverSection>();
 
         [Header("Notas detalladas (texto plano)")]
@@ -119,7 +118,7 @@ public class GameObjectNotes : MonoBehaviour
             if (string.IsNullOrEmpty(n.dateCreated))
                 n.dateCreated = DateTime.Now.ToString("dd/MM/yyyy");
 
-            if (string.IsNullOrEmpty(n.discoverName))
+            if (string.IsNullOrEmpty(n.discoverName) || n.discoverName == "Discover")
                 n.discoverName = gameObject.name;
 
             if (n.discoverSections == null)

--- a/Packages/com.jaimecamacho.discovernotes/Runtime/NoteStyles.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Runtime/NoteStyles.cs
@@ -17,7 +17,7 @@ public class NoteStyles : ScriptableObject
     [Header("Authors (dropdown)")]
     public List<string> authors = new List<string>
     {
-        "Carlos","David","Avelino","Gaspar","Anónimo"
+        "Carlos","David","Avelino","Gaspar","Annimo"
     };
 
     [Header("Categories")]
@@ -48,5 +48,18 @@ public class NoteStyles : ScriptableObject
             tooltipAccentBar=new Color(1.00f,1f,1f,1f),
             tooltipBackground=new Color(0.6f,0.6f,0.6f,1f)
         }
+    };
+
+    [Header("Discover disciplines (dropdown)")]
+    public List<string> discoverDisciplines = new List<string>
+    {
+        "FX",
+        "Audio",
+        "Gameplay",
+        "UI / UX",
+        "Environment",
+        "Systems / Code",
+        "Workflow / Pipeline",
+        "Other"
     };
 }


### PR DESCRIPTION
## Summary
- allow overriding discover discipline labels via the shared NoteStyles configuration and cache them for editor use
- normalize GameObjectNotes defaults so the Discover title comes from the object name instead of the old placeholder
- refresh the inspector UI to render Discover content inside a unified card with dynamic titles, aspect-preserving images and repaint-safe toggles

## Testing
- not run (editor-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68d13869d8c08326a214a1a21b056b8a