### PR TITLE
Fix DiscoverVZ editor category enum reference

### DIFF
--- a/Packages/com.jaimecamacho.discovernotes/Editor/DiscoverVZEditor.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Editor/DiscoverVZEditor.cs
@@ -55,7 +55,7 @@ public class DiscoverVZEditor : Editor
         {
             // Modo Edición
             discover.discoverName = EditorGUILayout.TextField("Name", discover.discoverName);
-            discover.category = (DiscoverVZ.DiscoverCategory)EditorGUILayout.EnumPopup("Category", discover.category);
+            discover.category = (DiscoverCategory)EditorGUILayout.EnumPopup("Category", discover.category);
             discover.image = (Texture2D)EditorGUILayout.ObjectField("Image", discover.image, typeof(Texture2D), false);
             discover.description = EditorGUILayout.TextArea(discover.description, GUILayout.Height(50));
 


### PR DESCRIPTION
## Summary
- update the DiscoverVZ custom inspector to use the shared DiscoverCategory enum instead of a nonexistent nested type

## Testing
- not run (Unity editor project)

------
https://chatgpt.com/codex/tasks/task_b_68d1414ce4bc832683cc541d1adaf01c