### PR TITLE
Fix Discover disciplines dropdown cache refresh

### DIFF
--- a/Packages/com.jaimecamacho.discovernotes/Runtime/NoteStyles.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Runtime/NoteStyles.cs
@@ -62,4 +62,11 @@ public class NoteStyles : ScriptableObject
         "Workflow / Pipeline",
         "Other"
     };
+
+#if UNITY_EDITOR
+    void OnValidate()
+    {
+        NoteStylesProvider.NotifyStylesModified(this);
+    }
+#endif
 }

--- a/Packages/com.jaimecamacho.discovernotes/Runtime/NoteStylesProvider.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Runtime/NoteStylesProvider.cs
@@ -39,6 +39,18 @@ public static class NoteStylesProvider
         s_lastCategoryForFind = null;
     }
 
+    internal static void NotifyStylesModified(NoteStyles styles)
+    {
+        if (styles == null)
+        {
+            ClearCaches();
+            return;
+        }
+
+        s_cachedStyles = styles;
+        BuildSimpleCaches();
+    }
+
     public static NoteStyles GetOrCreateStyles()
     {
         if (s_cachedStyles != null)


### PR DESCRIPTION
## Summary
- add a notification hook in `NoteStylesProvider` to rebuild cached dropdown data when the styles asset changes
- invoke the notification from `NoteStyles.OnValidate` so Discover discipline options refresh immediately

## Testing
- not run (editor-only change)


------
https://chatgpt.com/codex/tasks/task_b_68d14cd9c3c8832687f5697095832dfd