### PR TITLE
Fix Discover discipline dropdown options

### DIFF
--- a/Packages/com.jaimecamacho.discovernotes/Runtime/DiscoverNoteContent.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Runtime/DiscoverNoteContent.cs
@@ -8,13 +8,13 @@ using UnityEngine;
 /// </summary>
 public enum DiscoverCategory
 {
-    [InspectorName("FX")] VisualEffects,
+    [InspectorName("FX")] FX,
     [InspectorName("Audio")] Audio,
     [InspectorName("Gameplay")] Gameplay,
-    [InspectorName("UI / UX")] UI,
+    [InspectorName("UI / UX")] UIUX,
     [InspectorName("Environment")] Environment,
-    [InspectorName("Systems / Code")] Systems,
-    [InspectorName("Workflow / Pipeline")] Workflow,
+    [InspectorName("Systems / Code")] SystemsCode,
+    [InspectorName("Workflow / Pipeline")] WorkflowPipeline,
     [InspectorName("Other")] Other
 }
 
@@ -48,6 +48,26 @@ public static class DiscoverCategoryUtility
 
     public static string GetDisplayName(DiscoverCategory category)
     {
+        switch (category)
+        {
+            case DiscoverCategory.FX:
+                return "FX";
+            case DiscoverCategory.Audio:
+                return "Audio";
+            case DiscoverCategory.Gameplay:
+                return "Gameplay";
+            case DiscoverCategory.UIUX:
+                return "UI / UX";
+            case DiscoverCategory.Environment:
+                return "Environment";
+            case DiscoverCategory.SystemsCode:
+                return "Systems / Code";
+            case DiscoverCategory.WorkflowPipeline:
+                return "Workflow / Pipeline";
+            case DiscoverCategory.Other:
+                return "Other";
+        }
+
         var members = typeof(DiscoverCategory).GetMember(category.ToString());
         if (members != null && members.Length > 0)
         {

--- a/Packages/com.jaimecamacho.discovernotes/Runtime/NoteStylesProvider.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Runtime/NoteStylesProvider.cs
@@ -174,6 +174,8 @@ public static class NoteStylesProvider
 
     public static string[] GetDisciplineNamesCopy()
     {
+        GetOrCreateStyles();
+
         if (s_cachedDisciplineNames == null || s_cachedDisciplineNames.Length == 0)
             return DiscoverCategoryUtility.GetDisplayNamesCopy();
 
@@ -184,10 +186,11 @@ public static class NoteStylesProvider
 
     public static string GetDisciplineDisplayName(DiscoverCategory category)
     {
+        var names = GetDisciplineNamesCopy();
         int idx = (int)category;
-        if (s_cachedDisciplineNames != null && idx >= 0 && idx < s_cachedDisciplineNames.Length)
+        if (names != null && idx >= 0 && idx < names.Length)
         {
-            string name = s_cachedDisciplineNames[idx];
+            string name = names[idx];
             if (!string.IsNullOrEmpty(name))
                 return name;
         }


### PR DESCRIPTION
## Summary
- rename DiscoverCategory enum values to match the Discover discipline list
- ensure NoteStylesProvider always supplies readable names for the discipline popup

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_b_68d1532cdd988326b525cf96f0566777