### PR TITLE
Remove date metadata from game object notes UI

### DIFF
--- a/Packages/com.jaimecamacho.discovernotes/Editor/GameObjectNotesEditor.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Editor/GameObjectNotesEditor.cs
@@ -42,9 +42,6 @@ public class GameObjectNotesEditor : Editor
         "Área",
         "Disciplina o equipo responsable de la nota (Gameplay, FX, Audio, etc.).");
     static readonly GUIContent DiscoverImageContent = new GUIContent("Imagen principal");
-    static readonly GUIContent DateCreatedContent = new GUIContent(
-        "Fecha",
-        "Fecha de creación de la nota (formato dd/MM/yyyy).");
     static readonly GUIContent DiscoverSectionsContent = new GUIContent("Secciones");
     static readonly GUIContent ActionsLabelContent = new GUIContent("Acciones");
 
@@ -385,7 +382,6 @@ public class GameObjectNotesEditor : Editor
         var pAuthor = pNote.FindPropertyRelative("author");
         var pCategory = pNote.FindPropertyRelative("category");
         var pDiscipline = pNote.FindPropertyRelative("discoverCategory");
-        var pDate = pNote.FindPropertyRelative("dateCreated");
 
         float rowH = Mathf.Max(EditorGUIUtility.singleLineHeight + 6f, 22f);
         Rect row = EditorGUILayout.GetControlRect(false, rowH);
@@ -401,8 +397,6 @@ public class GameObjectNotesEditor : Editor
         DrawDiscoverDisciplinePopup(disciplineRect, pDiscipline);
         EditorIconHelper.DrawIconPopupAuthor(authorRect, pAuthor, NoteStylesProvider.GetAuthors());
 
-        // Botón fecha con popup anclado al rect del control
-        EditorGUILayout.PropertyField(pDate, DateCreatedContent);
     }
 
 
@@ -692,7 +686,6 @@ public class GameObjectNotesEditor : Editor
     {
         string category = pNote.FindPropertyRelative("category").stringValue ?? "Info";
         string author = pNote.FindPropertyRelative("author").stringValue;
-        string date = pNote.FindPropertyRelative("dateCreated").stringValue;
         string title = pNote.FindPropertyRelative("discoverName")?.stringValue;
         if (string.IsNullOrWhiteSpace(title)) title = category;
 
@@ -706,7 +699,6 @@ public class GameObjectNotesEditor : Editor
         int headerImageId = headerTexture != null ? headerTexture.GetInstanceID() : 0;
 
         string authorLabel = string.IsNullOrEmpty(author) ? "Anónimo" : author;
-        string dateLabel = string.IsNullOrEmpty(date) ? DateTime.Now.ToString("dd/MM/yyyy") : date;
         var pBody = pNote.FindPropertyRelative("notes");
         string raw = pBody.stringValue ?? string.Empty;
         var pShowHierarchy = pNote.FindPropertyRelative("showInHierarchy");
@@ -721,7 +713,7 @@ public class GameObjectNotesEditor : Editor
         if (!s_preview.TryGetValue(key, out var cache)) { cache = new PreviewCache(); s_preview[key] = cache; }
 
         int textHash = raw.GetHashCode();
-        int metaHash = (category + "|" + authorLabel + "|" + dateLabel + "|" + discipline + "|" + title).GetHashCode();
+        int metaHash = (category + "|" + authorLabel + "|" + discipline + "|" + title).GetHashCode();
         metaHash = unchecked(metaHash * 397) ^ headerImageId;
         float availWidth = EditorGUIUtility.currentViewWidth - 20f;
         if (availWidth <= 0f) availWidth = 400f;
@@ -745,7 +737,7 @@ public class GameObjectNotesEditor : Editor
             cache.headerIconSize = headerIcon != null
                 ? (headerTexture != null ? HEADER_IMAGE_SIZE : ICON)
                 : 0f;
-            cache.titleGC = new GUIContent($"<b>{title}</b>\n{category} • {discipline} • {authorLabel} • {dateLabel}");
+            cache.titleGC = new GUIContent($"<b>{title}</b>\n{category} • {discipline} • {authorLabel}");
 
             cache.links.Clear(); cache.checks.Clear(); cache.images.Clear();
             string displayStyled = LinkMarkup.BuildStyled(raw, cache.links, cache.checks, cache.images, out cache.indexMap);

--- a/Packages/com.jaimecamacho.discovernotes/Editor/NotesTooltipWindow.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Editor/NotesTooltipWindow.cs
@@ -166,7 +166,6 @@ public class NotesTooltipWindow : EditorWindow
 
         // --- CABECERA (meta) para el título de la banda superior ---
         string author = string.IsNullOrEmpty(_noteData?.author) ? "Anónimo" : _noteData.author;
-        string date = string.IsNullOrEmpty(_noteData?.dateCreated) ? DateTime.Now.ToString("dd/MM/yyyy") : _noteData.dateCreated;
 
         string discipline = _noteData != null
             ? DiscoverCategoryUtility.GetDisplayName(_noteData.discoverCategory)
@@ -182,7 +181,7 @@ public class NotesTooltipWindow : EditorWindow
         );
 
         // IMPORTANTE: inicializamos titleGC para que jamás sea null
-        titleGC = new GUIContent(BuildOneLineTitle(metaCat, author, date, maxTitleW, titleStyle));
+        titleGC = new GUIContent(BuildOneLineTitle(metaCat, author, maxTitleW, titleStyle));
 
 
 
@@ -253,24 +252,21 @@ public class NotesTooltipWindow : EditorWindow
 
     }
 
-        string BuildOneLineTitle(string category, string author, string date, float maxW, GUIStyle st)
+        string BuildOneLineTitle(string category, string author, float maxW, GUIStyle st)
     {
         string Sep = "  •  ";
         string Bold(string s) => $"<b>{s}</b>";
-        string Compose(string c, string a, string d) => $"{Bold(c)}{Sep}{a}{Sep}{d}";
+        string Compose(string c, string a) => $"{Bold(c)}{Sep}{a}";
 
-        string c = category, a = author, d = date;
+        string c = category, a = author;
 
-        if (st.CalcSize(new GUIContent(Compose(c, a, d))).x <= maxW) return Compose(c, a, d);
+        if (st.CalcSize(new GUIContent(Compose(c, a))).x <= maxW) return Compose(c, a);
 
-        c = ShrinkPart(c, cx => Compose(cx, a, d), maxW, st);
-        if (st.CalcSize(new GUIContent(Compose(c, a, d))).x <= maxW) return Compose(c, a, d);
+        c = ShrinkPart(c, cx => Compose(cx, a), maxW, st);
+        if (st.CalcSize(new GUIContent(Compose(c, a))).x <= maxW) return Compose(c, a);
 
-        a = ShrinkPart(a, ax => Compose(c, ax, d), maxW, st);
-        if (st.CalcSize(new GUIContent(Compose(c, a, d))).x <= maxW) return Compose(c, a, d);
-
-        d = ShrinkPart(d, dx => Compose(c, a, dx), maxW, st);
-        return Compose(c, a, d);
+        a = ShrinkPart(a, ax => Compose(c, ax), maxW, st);
+        return Compose(c, a);
     }
 
     string ShrinkPart(string original, Func<string, string> withPart, float maxW, GUIStyle st)


### PR DESCRIPTION
## Summary
- hide the creation date field from the GameObject Notes inspector
- drop the date metadata from the fixed card header and tooltip content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d68f04fe1c8326b5ad26a1a2dc91d3