### PR TITLE
Adjust discover image field layout

### DIFF
--- a/Packages/com.jaimecamacho.discovernotes/Editor/GameObjectNotesEditor.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Editor/GameObjectNotesEditor.cs
@@ -366,16 +366,8 @@ public class GameObjectNotesEditor : Editor
         var pImage = pNote.FindPropertyRelative("discoverImage");
         if (pImage != null)
         {
-            EditorGUI.BeginChangeCheck();
-            var newTex = (Texture2D)EditorGUILayout.ObjectField(
-                DiscoverImageContent,
-                pImage.objectReferenceValue,
-                typeof(Texture2D),
-                false);
-            if (EditorGUI.EndChangeCheck())
-            {
-                pImage.objectReferenceValue = newTex;
-            }
+            Rect imageRect = EditorGUILayout.GetControlRect(false, EditorGUIUtility.singleLineHeight);
+            EditorGUI.PropertyField(imageRect, pImage, DiscoverImageContent);
         }
 
 


### PR DESCRIPTION
## Summary
- draw the discover image property using a single-line horizontal field so it matches the section image layout

## Testing
- not run (UI/editor change)


------
https://chatgpt.com/codex/tasks/task_b_68d69138e17483268cd899928925919e