### PR TITLE
Remove Discover note images and improve section editing

### DIFF
--- a/Assets/3-Scenes/Main.unity
+++ b/Assets/3-Scenes/Main.unity
@@ -160,7 +160,6 @@ MonoBehaviour:
     category: Info
     discoverName: GameObject (1)
     discoverCategory: 7
-    discoverImage: {fileID: 0}
     discoverSummary: 
     discoverSections: []
     notes: 
@@ -343,16 +342,13 @@ MonoBehaviour:
     category: Info
     discoverName: GameObject
     discoverCategory: 4
-    discoverImage: {fileID: 0}
     discoverSummary: holliiii
     discoverSections:
     - sectionName: DASDA
-      image: {fileID: 10305, guid: 0000000000000000f000000000000000, type: 0}
       target: {fileID: 0}
       sectionContent: 
       actions: []
     - sectionName: DASDA
-      image: {fileID: 10305, guid: 0000000000000000f000000000000000, type: 0}
       target: {fileID: 0}
       sectionContent: 
       actions: []

--- a/Packages/com.jaimecamacho.discovernotes/Runtime/DiscoverNoteContent.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Runtime/DiscoverNoteContent.cs
@@ -82,13 +82,12 @@ public static class DiscoverCategoryUtility
 
 /// <summary>
 /// A section of structured information inside a Discover note. Sections allow grouping
-/// rich descriptions, optional imagery and navigation actions.
+/// rich descriptions and navigation actions.
 /// </summary>
 [Serializable]
 public class DiscoverSection
 {
     public string sectionName;
-    public Texture2D image;
 
     // NUEVO: objeto objetivo de la sección
     public GameObject target;

--- a/Packages/com.jaimecamacho.discovernotes/Runtime/GameObjectNotes.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Runtime/GameObjectNotes.cs
@@ -44,7 +44,6 @@ public class GameObjectNotes : MonoBehaviour
 
         public string discoverName = string.Empty;
         public DiscoverCategory discoverCategory = DiscoverCategory.Other;
-        public Texture2D discoverImage;
 
         [TextArea(2, 10)]
         public string discoverSummary = "";
@@ -63,8 +62,7 @@ public class GameObjectNotes : MonoBehaviour
 
         public bool HasDiscoverContent()
         {
-            return discoverImage != null
-                || !string.IsNullOrEmpty(discoverSummary)
+            return !string.IsNullOrEmpty(discoverSummary)
                 || (discoverSections != null && discoverSections.Count > 0);
         }
     }


### PR DESCRIPTION
## Summary
- remove the Discover image fields from note data and section definitions
- refresh the inspector tooling to drop image widgets and add a custom plain text editor for section content
- update serialized scene data to reflect the new schema

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_b_68da3649ce3883269acc070fcb046347