### PR TITLE
Fix link interactions after inline images

### DIFF
--- a/Packages/com.jaimecamacho.discovernotes/Editor/GameObjectNotesEditor.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Editor/GameObjectNotesEditor.cs
@@ -1244,8 +1244,9 @@ public class GameObjectNotesEditor : Editor
                             ttBodyStyle, new GUIContent(segText), segMap, tmp);
                         foreach (var t in tmp)
                         {
-                            var real = cache.links.Find(x => x.id == t.id && x.name == t.name &&
-                                                             x.vStart + segVisStart == t.vStart + segVisStart);
+                            var real = cache.links.Find(x => x.id == t.id
+                                                             && x.name == t.name
+                                                             && x.vStart == t.vStart + segVisStart);
                             if (real != null) real.hitRects.AddRange(t.hitRects);
                         }
                     }
@@ -1351,8 +1352,9 @@ public class GameObjectNotesEditor : Editor
                         ttBodyStyle, new GUIContent(segText), segMap, tmp);
                     foreach (var t in tmp)
                     {
-                        var real = cache.links.Find(x => x.id == t.id && x.name == t.name &&
-                                                         x.vStart + segVisStart == t.vStart + segVisStart);
+                        var real = cache.links.Find(x => x.id == t.id
+                                                         && x.name == t.name
+                                                         && x.vStart == t.vStart + segVisStart);
                         if (real != null) real.hitRects.AddRange(t.hitRects);
                     }
                 }

--- a/Packages/com.jaimecamacho.discovernotes/Editor/NotesTooltipWindow.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Editor/NotesTooltipWindow.cs
@@ -522,8 +522,9 @@ public class NotesTooltipWindow : EditorWindow
                             bodyStyle, new GUIContent(segText), segMap, tmp);
                         foreach (var t in tmp)
                         {
-                            var real = _links.Find(x => x.id == t.id && x.name == t.name &&
-                                                        x.vStart + segVisStart == t.vStart + segVisStart);
+                            var real = _links.Find(x => x.id == t.id
+                                                        && x.name == t.name
+                                                        && x.vStart == t.vStart + segVisStart);
                             if (real != null) real.hitRects.AddRange(t.hitRects);
                         }
                     }
@@ -627,8 +628,9 @@ public class NotesTooltipWindow : EditorWindow
                         bodyStyle, new GUIContent(segText), segMap, tmp);
                     foreach (var t in tmp)
                     {
-                        var real = _links.Find(x => x.id == t.id && x.name == t.name &&
-                                                    x.vStart + segVisStart == t.vStart + segVisStart);
+                        var real = _links.Find(x => x.id == t.id
+                                                    && x.name == t.name
+                                                    && x.vStart == t.vStart + segVisStart);
                         if (real != null) real.hitRects.AddRange(t.hitRects);
                     }
                 }


### PR DESCRIPTION
## Summary
- ensure the inspector view maps link hit rectangles using absolute positions so entries after inline images remain clickable
- mirror the same fix in the tooltip window to keep hierarchy popups consistent

## Testing
- not run (editor-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68da4f31573c83269b5efa7f5e40bfb8