### PR TITLE
Add VAT UV atlas generation tooling

### DIFF
--- a/Packages/com.jaimecamacho.discovernotes/Editor/GameObjectNotesEditor.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Editor/GameObjectNotesEditor.cs
@@ -1,6 +1,7 @@
 #if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using UnityEditor;
@@ -46,6 +47,20 @@ public class GameObjectNotesEditor : Editor
     static readonly GUIContent NoteActionsContent = new GUIContent("Acciones de la nota");
     static readonly GUIContent AddNoteButtonContent = new GUIContent("Añadir nota");
     static readonly GUIContent RemoveNoteButtonContent = new GUIContent("Eliminar nota");
+    static readonly GUIContent VatSectionTitleContent = new GUIContent("VAT UV Visual");
+    static readonly GUIContent VatReferenceTexturesContent = new GUIContent(
+        "Texturas de referencia",
+        "Lista de texturas base que se empaquetarán en un atlas de referencia para VAT UV Visual.");
+    static readonly GUIContent VatImagesCountContent = new GUIContent(
+        "Imágenes en el atlas",
+        "Número de texturas de la lista que se combinarán en el atlas final (se usan en orden).");
+    static readonly GUIContent VatColumnsContent = new GUIContent(
+        "Columnas",
+        "Cantidad de columnas que tendrá el atlas generado.");
+    static readonly GUIContent VatAtlasContent = new GUIContent(
+        "Atlas de referencia",
+        "Textura de atlas generada automáticamente para VAT UV Visual.");
+    static readonly GUIContent VatGenerateButtonContent = new GUIContent("Generar atlas VAT UV");
 
     // Edición en TextArea (plana con scrollbar)
     private const string NotesControlName = "NOTES_TEXTAREA_CONTROL";
@@ -666,6 +681,9 @@ public class GameObjectNotesEditor : Editor
         GUILayout.Space(8);
         DrawDiscoverSectionsEdit(pNote, noteIndex);
 
+        GUILayout.Space(10f);
+        DrawVatUvVisualSection(pNote);
+
         GUILayout.Space(12f);
         EditorGUILayout.LabelField(NoteActionsContent, EditorStyles.miniBoldLabel);
         using (new EditorGUILayout.HorizontalScope(EditorStyles.helpBox))
@@ -690,6 +708,269 @@ public class GameObjectNotesEditor : Editor
         }
     }
 
+    void DrawVatUvVisualSection(SerializedProperty pNote)
+    {
+        if (pNote == null) return;
+
+        var pReferenceTextures = pNote.FindPropertyRelative("vatReferenceTextures");
+        var pAtlas = pNote.FindPropertyRelative("vatReferenceAtlas");
+        var pImagesCount = pNote.FindPropertyRelative("vatAtlasImageCount");
+        var pColumns = pNote.FindPropertyRelative("vatAtlasColumnCount");
+
+        EditorGUILayout.LabelField(VatSectionTitleContent, EditorStyles.miniBoldLabel);
+        GUILayout.Space(2f);
+
+        if (pReferenceTextures != null)
+        {
+            EditorGUILayout.PropertyField(pReferenceTextures, VatReferenceTexturesContent, true);
+        }
+
+        int validTextures = CountValidVatTextures(pReferenceTextures);
+
+        using (new EditorGUI.IndentLevelScope())
+        {
+            if (validTextures > 0)
+            {
+                if (pImagesCount != null)
+                {
+                    int desired = pImagesCount.intValue <= 0 ? validTextures : pImagesCount.intValue;
+                    desired = Mathf.Clamp(desired, 1, validTextures);
+                    desired = EditorGUILayout.IntSlider(VatImagesCountContent, desired, 1, validTextures);
+                    pImagesCount.intValue = desired;
+
+                    if (pColumns != null)
+                    {
+                        int maxColumns = Mathf.Max(1, desired);
+                        int currentColumns = pColumns.intValue <= 0 ? Mathf.Min(desired, 4) : pColumns.intValue;
+                        currentColumns = Mathf.Clamp(currentColumns, 1, maxColumns);
+                        currentColumns = EditorGUILayout.IntSlider(VatColumnsContent, currentColumns, 1, maxColumns);
+                        pColumns.intValue = currentColumns;
+
+                        EditorGUILayout.LabelField(
+                            $"Se usarán las primeras {desired} texturas en el orden actual.",
+                            EditorStyles.miniLabel);
+                    }
+                }
+            }
+            else
+            {
+                EditorGUILayout.HelpBox(
+                    "Añade texturas a la lista para poder generar el atlas de referencia VAT.",
+                    MessageType.Info);
+                if (pImagesCount != null && pImagesCount.intValue != 0) pImagesCount.intValue = 0;
+                if (pColumns != null && pColumns.intValue < 1) pColumns.intValue = 1;
+            }
+        }
+
+        if (pAtlas != null)
+        {
+            EditorGUILayout.PropertyField(pAtlas, VatAtlasContent);
+        }
+
+        GUILayout.Space(2f);
+        using (new EditorGUILayout.HorizontalScope())
+        {
+            GUILayout.FlexibleSpace();
+            using (new EditorGUI.DisabledScope(validTextures == 0))
+            {
+                if (GUILayout.Button(VatGenerateButtonContent, GUILayout.Width(200f)))
+                {
+                    GenerateVatReferenceAtlas(pNote, pReferenceTextures, pAtlas, pImagesCount, pColumns);
+                }
+            }
+            GUILayout.FlexibleSpace();
+        }
+
+        DrawVatAtlasPreview(pAtlas, pImagesCount?.intValue ?? 0, pColumns?.intValue ?? 0);
+    }
+
+    int CountValidVatTextures(SerializedProperty texturesProperty)
+    {
+        if (texturesProperty == null || !texturesProperty.isArray) return 0;
+
+        int count = 0;
+        for (int i = 0; i < texturesProperty.arraySize; i++)
+        {
+            var element = texturesProperty.GetArrayElementAtIndex(i);
+            if (element != null && element.propertyType == SerializedPropertyType.ObjectReference
+                && element.objectReferenceValue is Texture2D)
+            {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    void DrawVatAtlasPreview(SerializedProperty atlasProperty, int imagesCount, int columns)
+    {
+        if (atlasProperty == null) return;
+        var atlasTex = atlasProperty.objectReferenceValue as Texture2D;
+        if (atlasTex == null) return;
+
+        GUILayout.Space(6f);
+        float aspect = atlasTex.height > 0 ? (float)atlasTex.width / atlasTex.height : 1f;
+        aspect = Mathf.Clamp(aspect, 0.1f, 10f);
+        Rect previewRect = GUILayoutUtility.GetAspectRect(aspect, GUILayout.Height(180f));
+        EditorGUI.DrawPreviewTexture(previewRect, atlasTex, null, ScaleMode.ScaleToFit);
+        if (Event.current.type == EventType.Repaint)
+        {
+            Handles.DrawSolidRectangleWithOutline(previewRect, Color.clear, new Color(1f, 1f, 1f, 0.2f));
+        }
+
+        GUILayout.Space(2f);
+        int shownImages = Mathf.Max(0, imagesCount);
+        int shownColumns = Mathf.Max(1, columns);
+        EditorGUILayout.LabelField(
+            $"{atlasTex.width} × {atlasTex.height}px • {shownImages} imágenes • {shownColumns} columnas",
+            EditorStyles.miniLabel);
+    }
+
+    void GenerateVatReferenceAtlas(SerializedProperty pNote,
+                                   SerializedProperty texturesProperty,
+                                   SerializedProperty atlasProperty,
+                                   SerializedProperty imagesCountProperty,
+                                   SerializedProperty columnsProperty)
+    {
+        if (texturesProperty == null || !texturesProperty.isArray)
+        {
+            EditorUtility.DisplayDialog("VAT UV Visual", "No se encontraron texturas de referencia.", "Aceptar");
+            return;
+        }
+
+        var textures = new List<Texture2D>();
+        for (int i = 0; i < texturesProperty.arraySize; i++)
+        {
+            var element = texturesProperty.GetArrayElementAtIndex(i);
+            if (element != null && element.propertyType == SerializedPropertyType.ObjectReference
+                && element.objectReferenceValue is Texture2D tex && tex != null)
+            {
+                textures.Add(tex);
+            }
+        }
+
+        if (textures.Count == 0)
+        {
+            EditorUtility.DisplayDialog("VAT UV Visual", "Añade texturas válidas antes de generar el atlas.", "Aceptar");
+            return;
+        }
+
+        int desiredImages = textures.Count;
+        if (imagesCountProperty != null && imagesCountProperty.intValue > 0)
+            desiredImages = Mathf.Clamp(imagesCountProperty.intValue, 1, textures.Count);
+
+        var texturesToUse = new List<Texture2D>();
+        for (int i = 0; i < Mathf.Min(desiredImages, textures.Count); i++)
+            texturesToUse.Add(textures[i]);
+
+        if (texturesToUse.Count == 0)
+        {
+            EditorUtility.DisplayDialog("VAT UV Visual", "No hay texturas válidas para generar el atlas.", "Aceptar");
+            return;
+        }
+
+        int columns = texturesToUse.Count;
+        if (columnsProperty != null && columnsProperty.intValue > 0)
+            columns = Mathf.Clamp(columnsProperty.intValue, 1, texturesToUse.Count);
+
+        if (!VatUvAtlasGenerator.TryBuildAtlas(texturesToUse, texturesToUse.Count, columns, out var result, out string error))
+        {
+            EditorUtility.DisplayDialog("VAT UV Visual", error ?? "No se pudo generar el atlas.", "Aceptar");
+            return;
+        }
+
+        string defaultName = BuildVatAtlasDefaultFileName(pNote);
+        string savePath = EditorUtility.SaveFilePanelInProject(
+            "Guardar atlas de referencia VAT UV",
+            defaultName,
+            "png",
+            "Selecciona la ubicación donde guardar el atlas generado.");
+
+        if (string.IsNullOrEmpty(savePath))
+        {
+            Object.DestroyImmediate(result.atlasTexture);
+            return;
+        }
+
+        try
+        {
+            SaveAtlasTextureAsPng(result.atlasTexture, savePath);
+        }
+        catch (System.Exception ex)
+        {
+            Object.DestroyImmediate(result.atlasTexture);
+            EditorUtility.DisplayDialog("VAT UV Visual", $"No se pudo guardar el atlas:\n{ex.Message}", "Aceptar");
+            return;
+        }
+
+        Object.DestroyImmediate(result.atlasTexture);
+
+        AssetDatabase.ImportAsset(savePath, ImportAssetOptions.ForceUpdate);
+        var atlasAsset = AssetDatabase.LoadAssetAtPath<Texture2D>(savePath);
+
+        Undo.RecordObject(tgt, "Generar atlas VAT UV");
+        if (atlasProperty != null)
+            atlasProperty.objectReferenceValue = atlasAsset;
+
+        if (imagesCountProperty != null)
+            imagesCountProperty.intValue = result.usedTextureCount;
+
+        if (columnsProperty != null)
+            columnsProperty.intValue = Mathf.Clamp(result.columns, 1, result.usedTextureCount);
+
+        serializedObject.ApplyModifiedProperties();
+        serializedObject.Update();
+
+        AssetDatabase.SaveAssets();
+        AssetDatabase.Refresh();
+        if (atlasAsset != null)
+            EditorGUIUtility.PingObject(atlasAsset);
+    }
+
+    string BuildVatAtlasDefaultFileName(SerializedProperty pNote)
+    {
+        string baseName = null;
+        if (pNote != null)
+        {
+            var pDiscoverName = pNote.FindPropertyRelative("discoverName");
+            if (pDiscoverName != null && !string.IsNullOrWhiteSpace(pDiscoverName.stringValue))
+                baseName = pDiscoverName.stringValue;
+        }
+
+        if (string.IsNullOrWhiteSpace(baseName))
+            baseName = tgt != null && tgt.gameObject != null ? tgt.gameObject.name : "VATAtlas";
+
+        baseName = SanitizeForFileName(baseName);
+        return string.IsNullOrEmpty(baseName) ? "VATAtlas" : $"{baseName}_VATAtlas";
+    }
+
+    string SanitizeForFileName(string name)
+    {
+        if (string.IsNullOrEmpty(name)) return "VATAtlas";
+
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var sb = new StringBuilder(name.Length);
+        for (int i = 0; i < name.Length; i++)
+        {
+            char c = name[i];
+            bool invalid = Array.IndexOf(invalidChars, c) >= 0 || c == '/';
+            sb.Append(invalid ? '_' : c);
+        }
+
+        string sanitized = sb.ToString().Trim();
+        return string.IsNullOrEmpty(sanitized) ? "VATAtlas" : sanitized;
+    }
+
+    void SaveAtlasTextureAsPng(Texture2D texture, string assetPath)
+    {
+        if (texture == null) throw new System.ArgumentNullException(nameof(texture));
+        if (string.IsNullOrEmpty(assetPath)) throw new System.ArgumentException("Ruta inválida", nameof(assetPath));
+
+        var pngData = texture.EncodeToPNG();
+        if (pngData == null || pngData.Length == 0)
+            throw new System.InvalidOperationException("No se pudo codificar el atlas en formato PNG.");
+
+        File.WriteAllBytes(assetPath, pngData);
+    }
 
     void DrawDiscoverContent_Fixed(SerializedProperty pNote)
     {

--- a/Packages/com.jaimecamacho.discovernotes/Editor/VatUvAtlasGenerator.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Editor/VatUvAtlasGenerator.cs
@@ -1,0 +1,131 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class VatUvAtlasGenerator
+{
+    public struct Result
+    {
+        public Texture2D atlasTexture;
+        public int usedTextureCount;
+        public int rows;
+        public int columns;
+        public int cellWidth;
+        public int cellHeight;
+    }
+
+    public static bool TryBuildAtlas(IReadOnlyList<Texture2D> textures,
+                                     int desiredCount,
+                                     int columns,
+                                     out Result result,
+                                     out string error)
+    {
+        result = default;
+        error = null;
+
+        if (textures == null)
+        {
+            error = "No se proporcionaron texturas de entrada.";
+            return false;
+        }
+
+        var validTextures = new List<Texture2D>();
+        for (int i = 0; i < textures.Count; i++)
+        {
+            if (textures[i] != null)
+            {
+                validTextures.Add(textures[i]);
+            }
+        }
+
+        if (validTextures.Count == 0)
+        {
+            error = "Añade al menos una textura de referencia.";
+            return false;
+        }
+
+        desiredCount = desiredCount <= 0 ? validTextures.Count : Mathf.Min(desiredCount, validTextures.Count);
+        desiredCount = Mathf.Clamp(desiredCount, 1, validTextures.Count);
+
+        columns = columns <= 0 ? desiredCount : Mathf.Clamp(columns, 1, desiredCount);
+        int rows = Mathf.CeilToInt(desiredCount / (float)columns);
+
+        int cellWidth = 0;
+        int cellHeight = 0;
+        for (int i = 0; i < desiredCount; i++)
+        {
+            var tex = validTextures[i];
+            if (tex == null) continue;
+            cellWidth = Mathf.Max(cellWidth, tex.width);
+            cellHeight = Mathf.Max(cellHeight, tex.height);
+        }
+
+        if (cellWidth <= 0 || cellHeight <= 0)
+        {
+            error = "Las texturas deben tener dimensiones mayores que cero.";
+            return false;
+        }
+
+        int atlasWidth = Mathf.Max(1, cellWidth * columns);
+        int atlasHeight = Mathf.Max(1, cellHeight * rows);
+
+        var rt = RenderTexture.GetTemporary(atlasWidth, atlasHeight, 0, RenderTextureFormat.ARGB32, RenderTextureReadWrite.Linear);
+        var previous = RenderTexture.active;
+        RenderTexture.active = rt;
+        GL.PushMatrix();
+        try
+        {
+            GL.LoadPixelMatrix(0, atlasWidth, 0, atlasHeight);
+            GL.Clear(true, true, Color.clear);
+
+            for (int i = 0; i < desiredCount; i++)
+            {
+                var tex = validTextures[i];
+                if (tex == null) continue;
+
+                int col = i % columns;
+                int row = i / columns;
+                float x = col * cellWidth + (cellWidth - tex.width) * 0.5f;
+                float y = (rows - 1 - row) * cellHeight + (cellHeight - tex.height) * 0.5f;
+
+                var destRect = new Rect(x, y, tex.width, tex.height);
+                Graphics.DrawTexture(destRect, tex, new Rect(0f, 0f, 1f, 1f), 0, 0, 0, 0);
+            }
+
+            var atlas = new Texture2D(atlasWidth, atlasHeight, TextureFormat.RGBA32, false, false)
+            {
+                name = $"VATAtlas_{desiredCount}",
+                wrapMode = TextureWrapMode.Clamp,
+                filterMode = FilterMode.Bilinear,
+                alphaIsTransparency = true
+            };
+
+            atlas.ReadPixels(new Rect(0, 0, atlasWidth, atlasHeight), 0, 0);
+            atlas.Apply(false, true);
+
+            result = new Result
+            {
+                atlasTexture = atlas,
+                usedTextureCount = desiredCount,
+                rows = rows,
+                columns = columns,
+                cellWidth = cellWidth,
+                cellHeight = cellHeight
+            };
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            return false;
+        }
+        finally
+        {
+            GL.PopMatrix();
+            RenderTexture.active = previous;
+            RenderTexture.ReleaseTemporary(rt);
+        }
+    }
+}
+#endif

--- a/Packages/com.jaimecamacho.discovernotes/Runtime/GameObjectNotes.cs
+++ b/Packages/com.jaimecamacho.discovernotes/Runtime/GameObjectNotes.cs
@@ -51,6 +51,12 @@ public class GameObjectNotes : MonoBehaviour
         [Header("Contenido estructurado")]
         public List<DiscoverSection> discoverSections = new List<DiscoverSection>();
 
+        [Header("VAT UV Visual")]
+        public List<Texture2D> vatReferenceTextures = new List<Texture2D>();
+        [Min(0)] public int vatAtlasImageCount = 0;
+        [Min(1)] public int vatAtlasColumnCount = 1;
+        public Texture2D vatReferenceAtlas;
+
         [Header("Notas detalladas (texto plano)")]
         [TextArea(3, 15)]
         public string notes = "";
@@ -127,6 +133,28 @@ public class GameObjectNotes : MonoBehaviour
                 var section = n.discoverSections[s];
                 if (section == null) { n.discoverSections[s] = section = new DiscoverSection(); }
                 if (section.actions == null) section.actions = new List<DiscoverAction>();
+            }
+
+            if (n.vatReferenceTextures == null)
+                n.vatReferenceTextures = new List<Texture2D>();
+
+            int validVatTextures = 0;
+            for (int v = 0; v < n.vatReferenceTextures.Count; v++)
+            {
+                if (n.vatReferenceTextures[v] != null)
+                    validVatTextures++;
+            }
+
+            if (validVatTextures <= 0)
+            {
+                n.vatAtlasImageCount = 0;
+                if (n.vatAtlasColumnCount < 1) n.vatAtlasColumnCount = 1;
+            }
+            else
+            {
+                if (n.vatAtlasImageCount <= 0) n.vatAtlasImageCount = validVatTextures;
+                n.vatAtlasImageCount = Mathf.Clamp(n.vatAtlasImageCount, 1, validVatTextures);
+                n.vatAtlasColumnCount = Mathf.Clamp(n.vatAtlasColumnCount, 1, n.vatAtlasImageCount);
             }
 
 #if UNITY_EDITOR


### PR DESCRIPTION
## Summary
- add VAT UV Visual data to notes so reference textures, atlas counts, and output assets are tracked
- extend the inspector to manage VAT UV reference textures, configure atlas layout, generate PNG assets, and preview the result
- implement a reusable editor helper that assembles texture grids into VAT UV atlases

## Testing
- not run (Unity editor functionality)


------
https://chatgpt.com/codex/tasks/task_b_68ff457ed60483269a33302dc8e360c4